### PR TITLE
Add portfolio section and GitHub Pages deployment

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,0 +1,64 @@
+name: Deploy Hugo site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: [master]
+  # Allows manual runs from the Actions tab
+  workflow_dispatch:
+
+# Permissions needed for GitHub Pages deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel in-progress production deploys
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      # Pin to the Hugo version verified locally. Bump as needed.
+      HUGO_VERSION: 0.162.1
+    steps:
+      - name: Install Hugo CLI (extended, for SCSS)
+        run: |
+          wget -O "${{ runner.temp }}/hugo.deb" \
+            "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb" \
+          && sudo dpkg -i "${{ runner.temp }}/hugo.deb"
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive   # pulls in the hugo-blog-awesome theme submodule
+          fetch-depth: 0          # full history so .GitInfo / .Lastmod work
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build with Hugo
+        env:
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: hugo --gc --minify
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/archetypes/portfolio.md
+++ b/archetypes/portfolio.md
@@ -1,0 +1,14 @@
+---
+title: '{{ replace .File.ContentBaseName "-" " " | title }}'
+date: '{{ .Date }}'
+weight: 100
+draft: true
+description: ""
+platform: "Web app"
+tech: []
+externalUrl: ""
+externalLabel: "Visit site"
+# image: "cover.png"   # optional — drop the image in this folder to enable
+---
+
+Write-up: what it does, the problem it solves, and notable technical decisions.

--- a/assets/sass/_custom.scss
+++ b/assets/sass/_custom.scss
@@ -1,0 +1,298 @@
+//////////////// Portfolio /////////////////
+// Project card grid used by the /portfolio list page and the homepage
+// "Selected work" strip. Reuses theme variables defined in main.scss.
+
+// External-link (arrow-up-right) icon, used as a CSS mask so it inherits the
+// element's `currentColor`. URL-encoded inline SVG (no extra HTTP request).
+$icon-external: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='7' y1='17' x2='17' y2='7'/%3E%3Cpolyline points='7 7 17 7 17 17'/%3E%3C/svg%3E");
+
+.portfolio-intro {
+    margin-bottom: $spacing-full;
+    color: $gray;
+}
+
+.portfolio-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: $spacing-half;
+    margin: $spacing-half 0 $spacing-full;
+
+    @include media-query($on-mobile) {
+        grid-template-columns: 1fr;
+    }
+}
+
+.portfolio-card {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border: 1px solid $smoke;
+    border-radius: 8px;
+    text-decoration: none;
+    color: inherit;
+    background-color: $white;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+
+    &:hover,
+    &:focus {
+        transform: translateY(-3px);
+        border-color: $text-link-blue;
+        box-shadow: 0 6px 20px rgba(13, 18, 43, 0.08);
+        color: inherit;
+    }
+
+    .portfolio-card-media {
+        line-height: 0;
+
+        img {
+            width: 100%;
+            height: 160px;
+            object-fit: cover;
+        }
+    }
+
+    .portfolio-card-body {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        padding: $spacing-half;
+    }
+
+    .portfolio-card-title {
+        margin: 0.4rem 0 0.3rem;
+        @include relative-font-size(1.15);
+    }
+
+    .portfolio-card-desc {
+        margin: 0 0 0.8rem;
+        color: $gray;
+        @include relative-font-size(0.95);
+    }
+
+    .portfolio-card-more {
+        margin-top: auto;
+        color: $text-link-blue;
+        font-weight: $bold-weight;
+        @include relative-font-size(0.9);
+    }
+}
+
+// Platform badge ("Web app", "iOS app", ...)
+.platform-badge {
+    display: inline-block;
+    // The card body is a flex column, whose default `align-items: stretch`
+    // would otherwise stretch the badge to the full card width.
+    align-self: flex-start;
+    padding: 2px 10px;
+    border-radius: 999px;
+    background-color: $light;
+    color: $gray;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    @include relative-font-size(0.72);
+    font-weight: $bold-weight;
+}
+
+// Tech tag pills
+.tech-tags {
+    list-style: none;
+    margin: 0 0 0.8rem;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+
+    .tech-tag {
+        margin: 0;
+        padding: 1px 9px;
+        border: 1px solid $smoke;
+        border-radius: 999px;
+        color: $gray;
+        @include relative-font-size(0.78);
+
+        &:before {
+            content: none;
+        }
+    }
+}
+
+// Detail page — breadcrumb (Home / Portfolio / Project), driven by .Ancestors.
+.breadcrumb {
+    margin-bottom: $spacing-full;
+    @include relative-font-size(0.875);
+    color: $gray;
+
+    ol {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.4em;
+    }
+
+    li {
+        margin: 0;
+
+        &:before {
+            content: none;
+        }
+    }
+
+    a {
+        color: $gray;
+        text-decoration: none;
+
+        &:hover,
+        &:focus {
+            color: $text-link-blue;
+            text-decoration: underline;
+        }
+    }
+
+    li[aria-current="page"] {
+        color: inherit;
+        font-weight: $bold-weight;
+    }
+
+    .sep {
+        color: $smoke;
+    }
+}
+
+// Detail page (single)
+.portfolio-detail-media {
+    margin: $spacing-half 0;
+    line-height: 0;
+
+    img {
+        width: 100%;
+        border-radius: 8px;
+    }
+}
+
+.portfolio-cta-wrap {
+    margin: $spacing-half 0 $spacing-full;
+}
+
+// Scoped under `.page-content` to outrank the theme's `.page-content a`
+// link-color rule, which would otherwise tint the label the same blue as the
+// button background and make it invisible.
+.page-content a.portfolio-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 11px 22px;
+    border-radius: 8px;
+    background-color: $text-link-blue;
+    color: $white;
+    font-weight: $bold-weight;
+    letter-spacing: 0.01em;
+    text-decoration: none;
+    transition: background-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+
+    &:hover,
+    &:focus {
+        background-color: $text-link-blue-active;
+        color: $white;
+        transform: translateY(-1px);
+        box-shadow: 0 4px 14px rgba(13, 18, 43, 0.18);
+    }
+
+    // Replace the theme's floating unicode "↗" (.page-content a[target=_blank]::after,
+    // equal specificity, so this later rule wins) with a properly-weighted,
+    // text-sized external-link icon. `currentColor` makes it match the label in
+    // both light and dark mode automatically.
+    &::after {
+        content: "";
+        position: static;
+        bottom: auto;
+        width: 1em;
+        height: 1em;
+        flex: none;
+        background-color: currentColor;
+        -webkit-mask: $icon-external center / contain no-repeat;
+        mask: $icon-external center / contain no-repeat;
+        transition: transform 0.15s ease;
+    }
+
+    &:hover::after,
+    &:focus::after {
+        transform: translate(2px, -2px);
+    }
+}
+
+//////////////// Portfolio — dark mode /////////////////
+// Mirrors the theme's _dark.scss strategy (html.dark + prefers-color-scheme).
+@mixin portfolio-dark-mode {
+    .portfolio-intro,
+    .portfolio-card .portfolio-card-desc,
+    .tech-tags .tech-tag {
+        color: $dark-gray;
+    }
+
+    .portfolio-card {
+        background-color: $dark-light;
+        border-color: $dark-smoke;
+
+        &:hover,
+        &:focus {
+            border-color: $dark-text-link-blue;
+            box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+        }
+
+        .portfolio-card-more {
+            color: $dark-text-link-blue;
+        }
+    }
+
+    .platform-badge {
+        background-color: $dark-black;
+        color: $dark-gray;
+    }
+
+    .tech-tags .tech-tag {
+        border-color: $dark-smoke;
+    }
+
+    .breadcrumb {
+        color: $dark-gray;
+
+        a {
+            color: $dark-gray;
+
+            &:hover,
+            &:focus {
+                color: $dark-text-link-blue;
+            }
+        }
+
+        .sep {
+            color: $dark-smoke;
+        }
+    }
+
+    // Match the elevated specificity used in light mode (see `.page-content
+    // a.portfolio-cta` above) so the theme's dark link color can't win.
+    .page-content a.portfolio-cta {
+        background-color: $dark-text-link-blue;
+        color: $dark-black;
+
+        &:hover,
+        &:focus {
+            background-color: $dark-text-link-blue-active;
+            color: $dark-black;
+        }
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    html:not(.light) {
+        @include portfolio-dark-mode;
+    }
+}
+
+html.dark {
+    @include portfolio-dark-mode;
+}

--- a/content/portfolio/_index.md
+++ b/content/portfolio/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Portfolio"
+description: "Things I've built in my spare time, for fun."
+---
+
+These are projects I build in my free time, for the fun of it. What changed
+everything is vibe coding — building hand-in-hand with AI agents. It's been a rocket
+engine: ideas that used to stay daydreams now turn into working apps in hours, so I
+get to chase far more of them. Open any card to read the story behind it.

--- a/content/portfolio/minesweeper/index.md
+++ b/content/portfolio/minesweeper/index.md
@@ -1,0 +1,34 @@
+---
+title: "Minesweeper by negfeed"
+date: 2026-01-01
+weight: 30
+description: "The timeless logic puzzle, rebuilt from the ground up for iPhone."
+platform: "iOS app"
+tech: ["iOS game", "Ad-free", "LLM-built", "Swift", "SwiftUI"]
+externalUrl: "https://apps.apple.com/us/app/minesweeper-by-negfeed/id6761509618"
+externalLabel: "View on the App Store"
+# image: "cover.png"   # optional — drop cover.png in this folder to enable
+---
+
+I was tired of mobile games buried under ads, and I wondered whether Claude Opus
+could help me build one that wasn't. It could — with a lot of high-level steering
+from me — and Minesweeper by negfeed is the result: the timeless logic puzzle,
+rebuilt from the ground up for touch, with no ads, no tracking, and no data
+collection.
+
+Tap to reveal, long-press or swipe to flag, pinch to zoom, and line up tricky taps
+with a floating loupe preview; auto-zoom, auto-pan, and chord support keep big
+boards manageable on a small screen. Play the classic Beginner, Intermediate, and
+Expert boards or dial in a custom difficulty, with a configurable undo system
+(unlimited, three charges, or off) so you decide how forgiving each game is. Wins
+come with haptics, sound, and confetti, and everything saves and resumes
+automatically with persistent stats and high scores. A short interactive tutorial
+gets new players started, and it runs on iOS 17 and later, plus Mac and Apple
+Vision.
+
+There's a fun story behind the hexagonal mode. My first submission to the App
+Store — square grid only — was rejected as spam. So I went back to Claude and asked
+how we could differentiate the app enough that it wouldn't be mistaken for one of a
+thousand clones. Among its suggestions was a hex grid: a six-neighbor variant that
+changes the deduction entirely. Watching Opus implement the whole hexagonal mode in
+a single prompt genuinely blew my mind.

--- a/content/portfolio/trip-escrow/index.md
+++ b/content/portfolio/trip-escrow/index.md
@@ -1,0 +1,34 @@
+---
+title: "Trip Escrow"
+date: 2026-01-01
+weight: 20
+description: "A smart escrow for couples planning a surprise trip — neither reveals their destination."
+platform: "Web app"
+tech: ["AI escrow agent", "Surprise trips", "LLM-built", "Gemini", "Cloud Run", "Firebase"]
+externalUrl: "https://trip-escrow.negfeed.com"
+externalLabel: "Visit site"
+# image: "cover.png"   # optional — drop cover.png in this folder to enable
+---
+
+The idea came from my longtime manager at Google Wallet, who mentioned that he and
+his boyfriend liked to surprise each other by secretly planning trips to different
+places. I loved it, and wanted to do the same with my wife: our birthdays are about
+two months apart, so we could each plan a getaway for the other — with one rule,
+that we don't both pick the same destination.
+
+Trip Escrow is the neutral middle that makes that work. One partner secretly locks
+in a destination — Gemini validates that it's a real, unambiguous place — while the
+other submits three options of their own. The app then uses Gemini to choose the
+option most geographically distinct from the hidden pick, so you both end up
+somewhere genuinely new, with the surprise intact until the reveal. Once a choice is
+made the session locks, so no one can peek or change their answer.
+
+The concept started as a prototype in Google AI Studio. From there I used Claude to
+rework the code to run on Google Cloud Run, with Firebase as the database. The front
+end is React with an Express API, and Gemini handles both the location validation
+and the final selection.
+
+More than the trip planning, I think the underlying pattern is the interesting part:
+using an LLM as a trusted escrow agent — something that holds a secret and acts on
+it fairly without leaking it to either side. As agents grow more secure and more
+trusted, I expect that opportunity to keep growing.

--- a/content/portfolio/vocalize/index.md
+++ b/content/portfolio/vocalize/index.md
@@ -1,0 +1,31 @@
+---
+title: "Vocalize"
+date: 2026-01-01
+weight: 10
+description: "A voice-first journal that transcribes what you say and distills it into daily and monthly AI summaries."
+platform: "Web app"
+tech: ["Voice journaling", "AI summaries", "LLM-built", "Replit", "Cloud Run", "Firebase", "Vertex AI"]
+externalUrl: "https://vocalize.negfeed.com"
+externalLabel: "Visit site"
+# image: "cover.png"   # optional — drop cover.png in this folder to enable
+---
+
+Vocalize is a diary I'd dreamed about for years — and one I could only build now.
+The idea was always the same: a journal you simply *talk* to, that quietly makes
+sense of what you said over time. For a long time it stayed a daydream, blocked on
+two hard problems. LLMs cleared both. They let me prototype and build the app far
+faster than I ever could have alone, and they finally made the core feature
+possible — turning rambling, spoken entries into summaries worth reading.
+
+So that's what it does. Speak freely and it captures your voice notes, transcribes
+them with Google Cloud Speech-to-Text, and uses Vertex AI to distill the day into a
+clean summary — then rolls those up into monthly summaries so you can look back
+across weeks at a glance. You can also open a chat and ask questions across
+everything you've recorded.
+
+I built the first version on Replit and had something working end to end —
+recording, transcription, and summaries — in under four hours. Once it was real,
+the catch was cost: Replit hosting added up quickly. So I had Claude Opus rework
+the code to run on Google Cloud Run instead, which dropped the hosting bill
+dramatically while keeping the same Express backend, Firebase database, and Vertex
+AI summarization.

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,10 +1,21 @@
-baseURL = 'https://example.org/'
+baseURL = 'https://blog.negfeed.com/'
 languageCode = 'en-us'
 title = "Mohammad Shamma's Page"
 theme = "hugo-blog-awesome"
 
 [params]
   goToTop = true
+  mainSections = ['posts'] # keeps the portfolio out of the homepage "recent posts" list
+
+[[menu.main]]
+  name = 'Home'
+  pageRef = '/'
+  weight = 10
+
+[[menu.main]]
+  name = 'Portfolio'
+  pageRef = '/portfolio'
+  weight = 20
 
 [params.author]
   avatar = "avatar.jpg" # put the file in assets folder; also ensure that image has same height and width
@@ -18,9 +29,5 @@ name = "github"
 url = "https://github.com/mohammadshamma"
 
 [[params.socialIcons]]
-name = "twitter"
-url = "https://twitter.com/mohammadshamma"
-
-[[params.socialIcons]]
-name = "Rss"
-url = "index.xml"
+name = "linkedin"
+url = "https://www.linkedin.com/in/mohammadshamma/"

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,53 @@
+<!--
+  Project override of the theme's RSS template.
+  The theme uses `.Site.Author.*`, which Hugo removed in v0.158. This copy is
+  identical except it reads the author from `site.Params.author.*` instead.
+  The author/editor tags are emitted only when `params.author.email` is set
+  (currently unset, so they are omitted — which is valid RSS).
+-->
+{{- $pctx := . -}}
+{{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
+{{- $pages := slice -}}
+{{- if or $.IsHome $.IsSection -}}
+{{- $pages = $pctx.RegularPages -}}
+{{- else -}}
+{{- $pages = $pctx.Pages -}}
+{{- end -}}
+{{- $limit := .Site.Config.Services.RSS.Limit -}}
+{{- if ge $limit 1 -}}
+{{- $pages = $pages | first $limit -}}
+{{- end -}}
+{{- $rssFeedDescription := .Site.Params.rssFeedDescription | default "summary" -}}
+{{- $author := site.Params.author -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>{{ site.Language.LanguageCode }}</language>{{ with $author.email }}
+    <managingEditor>{{.}}{{ with $author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with $author.email }}
+    <webMaster>{{.}}{{ with $author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{- with .OutputFormats.Get "RSS" -}}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end -}}
+    {{ range $pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{ with $author.email }}<author>{{.}}{{ with $author.name }} ({{.}}){{end}}</author>{{end}}
+      <guid>{{ .Permalink }}</guid>
+      {{ if eq $rssFeedDescription "summary"}}
+      <description>{{ .Summary | html }}</description>
+      {{ else if (eq $rssFeedDescription "full")}}
+      <description>{{ .Content | html }}</description>
+      {{ else }} {{ errorf "Error in RSS feed generation %q" .Path }}
+      {{ end }}
+    </item>
+    {{ end }}
+  </channel>
+</rss>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+{{- $defaultColor := .Site.Params.defaultColor | default "auto" -}}
+
+{{/* allow website developer to enforce default dark mode */}}
+{{- if eq $defaultColor "dark" -}}
+<html lang="{{ .Site.LanguageCode }}" class="dark">
+{{- else if eq $defaultColor "light" -}}
+<html lang="{{ .Site.LanguageCode }}" class="light">
+{{- else -}}
+<html lang="{{ .Site.LanguageCode }}">
+{{- end -}}
+
+{{- partial "head.html" . -}}
+
+<body data-theme="{{ $defaultColor }}" class="notransition">
+    {{- partial "scriptsBodyStart.html" . -}}
+    {{- partial "header.html" . -}}
+    <div class="wrapper">
+        {{ partial "bio" . }}
+        <main aria-label="Content">
+            {{/* Show last 5 posts in reverse date order */}}
+            {{ $pagesToShow := where .Site.RegularPages "Type" "in" site.Params.mainSections }}
+            {{ $posts := $pagesToShow.ByDate.Reverse }}
+            {{/* Only render the "Recent Posts" heading/section when there is at least one post */}}
+            {{ with $posts }}
+            <h3 class="posts-item-note" aria-label="Recent Posts">{{ T "home.recent_posts" }}</h3>
+            {{ range first 5 . }}
+            {{ partial "postCard" . }}
+            {{ end }}
+            {{ if gt (len .) 5 }}
+            <p>
+                {{ range $firstSection := (where $.Site.Sections "Section" "in" (first 1 ($.Site.Params.mainSections))) }}
+                <a href="{{ $firstSection.Permalink }}">{{ T "home.see_all_posts" }}</a>
+                {{ end }}
+            </p>
+            {{ end }}
+            {{ end }}
+        </main>
+    </div>
+    {{- partial "footer.html" . -}}
+    {{- partial "scriptsBodyEnd.html" . -}}
+</body>
+
+</html>

--- a/layouts/partials/portfolio-card.html
+++ b/layouts/partials/portfolio-card.html
@@ -1,0 +1,25 @@
+{{/*
+  portfolio-card.html — a single project card.
+  Context (.) is a portfolio project page. Used by the portfolio list page and
+  the homepage "Selected work" strip so the card markup stays in one place.
+*/}}
+<a class="portfolio-card" href="{{ .RelPermalink }}">
+    {{ with .Params.image }}
+    {{ with $.Resources.GetMatch . }}
+    <div class="portfolio-card-media">
+        <img src="{{ (.Resize "600x webp").RelPermalink }}" alt="{{ $.Title }}" loading="lazy">
+    </div>
+    {{ end }}
+    {{ end }}
+    <div class="portfolio-card-body">
+        {{ with .Params.platform }}<span class="platform-badge">{{ . }}</span>{{ end }}
+        <h3 class="portfolio-card-title">{{ .Title }}</h3>
+        {{ with .Params.description }}<p class="portfolio-card-desc">{{ . }}</p>{{ end }}
+        {{ with .Params.tech }}
+        <ul class="tech-tags">
+            {{ range . }}<li class="tech-tag">{{ . }}</li>{{ end }}
+        </ul>
+        {{ end }}
+        <span class="portfolio-card-more">View project &rarr;</span>
+    </div>
+</a>

--- a/layouts/portfolio/list.html
+++ b/layouts/portfolio/list.html
@@ -1,0 +1,17 @@
+{{- define "main" -}}
+<div class="wrapper list-page">
+    <header class="header">
+        <h1 class="header-title center">{{ .Title }}</h1>
+    </header>
+    <main class="page-content" aria-label="Content">
+        {{ with .Content }}
+        <div class="portfolio-intro">{{ . }}</div>
+        {{ end }}
+        <div class="portfolio-grid">
+            {{ range .Pages }}
+            {{ partial "portfolio-card.html" . }}
+            {{ end }}
+        </div>
+    </main>
+</div>
+{{- end -}}

--- a/layouts/portfolio/single.html
+++ b/layouts/portfolio/single.html
@@ -1,0 +1,49 @@
+{{ define "main" }}
+<div class="wrapper post">
+    <main class="page-content" aria-label="Content">
+        <article>
+            {{/* Native Hugo breadcrumb (Home / Portfolio / Project) via .Ancestors */}}
+            <nav class="breadcrumb" aria-label="Breadcrumb">
+                <ol>
+                    {{ range .Ancestors.Reverse }}
+                    <li><a href="{{ .RelPermalink }}">{{ if .IsHome }}Home{{ else }}{{ .LinkTitle }}{{ end }}</a></li>
+                    <li class="sep" aria-hidden="true">/</li>
+                    {{ end }}
+                    <li aria-current="page">{{ .LinkTitle }}</li>
+                </ol>
+            </nav>
+            <header class="header">
+                {{ with .Params.platform }}<span class="platform-badge">{{ . }}</span>{{ end }}
+                <h1 class="header-title">{{ .Title }}</h1>
+                {{ with .Params.tech }}
+                <ul class="tech-tags">
+                    {{ range . }}<li class="tech-tag">{{ . }}</li>{{ end }}
+                </ul>
+                {{ end }}
+            </header>
+
+            {{ with .Params.image }}
+            {{ with $.Resources.GetMatch . }}
+            <div class="portfolio-detail-media">
+                <img src="{{ (.Resize "1200x webp").RelPermalink }}" alt="{{ $.Title }}" loading="lazy">
+            </div>
+            {{ end }}
+            {{ end }}
+
+            {{ with .Params.externalUrl }}
+            <p class="portfolio-cta-wrap">
+                {{/* The theme auto-appends a ↗ glyph to external (target=_blank)
+                     links in .page-content, so we don't add one here. */}}
+                <a class="portfolio-cta" href="{{ . }}" target="_blank" rel="noopener">
+                    {{ $.Params.externalLabel | default "Visit site" }}
+                </a>
+            </p>
+            {{ end }}
+
+            <div class="page-content">
+                {{ .Content }}
+            </div>
+        </article>
+    </main>
+</div>
+{{ end }}

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+blog.negfeed.com


### PR DESCRIPTION
## Summary
- Adds a `/portfolio` section: responsive card grid + per-project detail pages for **Vocalize**, **Trip Escrow**, and **Minesweeper**, with concept/tech chips and a native `.Ancestors` breadcrumb.
- Homepage stays focused on the blog; portfolio reachable via a **Portfolio** nav item. `mainSections=['posts']` keeps projects out of the post feed, and the empty "Recent Posts" heading is hidden until posts exist.
- Social icons trimmed to **GitHub + LinkedIn** (removed Twitter and the RSS icon).
- Fixes a theme/Hugo incompatibility: overrides `layouts/_default/rss.xml` to use `site.Params.author` (the theme's `.Site.Author` was removed in Hugo v0.158 and broke the build).

## Deployment
- `baseURL` → `https://blog.negfeed.com/`, `static/CNAME` emits the custom domain.
- New GitHub Actions workflow builds Hugo **extended** (with the theme submodule) and deploys to Pages.

## After merge — manual steps
1. **DNS:** add `CNAME` record `blog` → `mohammadshamma.github.io`.
2. **Settings → Pages:** Source → **GitHub Actions**; Custom domain → `blog.negfeed.com`.
3. Enable **Enforce HTTPS** once the domain validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)