### PR TITLE
Add GA4 analytics (G-RZ2LNRDTNZ)

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -3,6 +3,10 @@ languageCode = 'en-us'
 title = "Mohammad Shamma's Page"
 theme = "hugo-blog-awesome"
 
+[services]
+  [services.googleAnalytics]
+    id = 'G-RZ2LNRDTNZ' # GA4 Measurement ID
+
 [params]
   goToTop = true
   mainSections = ['posts'] # keeps the portfolio out of the homepage "recent posts" list


### PR DESCRIPTION
Enables Google Analytics 4 on the site.

## What
Adds a `[services.googleAnalytics]` block to `hugo.toml` with Measurement ID `G-RZ2LNRDTNZ`. The theme (`hugo-blog-awesome`) reads this in `layouts/partials/head.html` and injects gtag.js **only on production builds** (`hugo.IsProduction`), which the deploy workflow sets via `HUGO_ENVIRONMENT=production`. Local `hugo server` is unaffected.

## Deploy
Merging to `master` triggers the existing **Deploy Hugo site to Pages** workflow, publishing to https://blog.negfeed.com/.

## Verify after merge
`curl -s https://blog.negfeed.com/ | grep -i G-RZ2LNRDTNZ` should match the `gtag/js?id=G-RZ2LNRDTNZ` snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)