### PR TITLE
Add private notes scratch space and blog authoring skills

### DIFF
--- a/.claude/skills/add-idea/SKILL.md
+++ b/.claude/skills/add-idea/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: add-idea
+description: Append a blog post idea to notes/ideas.md in this Hugo repo. Use when the user wants to jot down, capture, save, or log a blog/post idea, topic, or thing to write about for later — e.g. "add an idea", "note down a post idea", "I want to write about X someday".
+---
+
+# Add a blog post idea
+
+Append a new idea to `notes/ideas.md` at the repo root. This file is a scratch list that Hugo never builds, so it stays out of the published site.
+
+## Steps
+
+1. Determine the idea text from the user's request. If they didn't give a clear idea, ask them for the one-line idea before writing anything.
+2. Read `notes/ideas.md` (create it from the template below if it doesn't exist).
+3. Append a new bullet at the end of the file in this format:
+   ```
+   - [ ] <idea> — <optional one-line note on the angle/why>
+   ```
+   Keep the idea to a single line. Only include the `— note` part if the user gave context or you can add a genuinely useful angle; otherwise omit it.
+4. Confirm to the user what was added and show the new line.
+
+## Notes
+
+- Do NOT create files under `content/` — ideas live only in `notes/ideas.md`.
+- Preserve existing content; only append. Never reorder or rewrite other entries.
+- If the user gives several ideas at once, add one bullet per idea.
+
+## Template (only if notes/ideas.md is missing)
+
+```markdown
+# Blog Post Ideas
+
+A running list of post ideas.
+
+<!-- Format: - [ ] One-line idea — optional note on the angle/why -->
+```

--- a/.claude/skills/new-draft/SKILL.md
+++ b/.claude/skills/new-draft/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: new-draft
+description: Create a new blog post draft file under notes/drafts/ in this Hugo repo. Use when the user wants to start, scaffold, or begin drafting a new blog post, article, or write-up that should stay private (not published) for now — e.g. "start a draft about X", "new draft", "begin writing a post on Y".
+---
+
+# Create a new blog post draft
+
+Scaffold a new draft Markdown file under `notes/drafts/`. Hugo never builds anything under `notes/`, so drafts stay private to the repo until they're promoted into `content/posts/`.
+
+## Steps
+
+1. Determine the draft **title** from the user's request. If no title/topic is given, ask for one before creating the file.
+2. Derive a **slug** by lowercasing the title, replacing spaces and punctuation with hyphens, and collapsing repeats (e.g. "My First Post!" → `my-first-post`).
+3. Choose the file path `notes/drafts/<slug>.md`. If a file with that name already exists, ask the user whether to pick a different name rather than overwriting.
+4. Get today's date in `YYYY-MM-DD` form (run `date +%F`) for the front matter.
+5. Write the file using the template below, filling in the date and title.
+6. Confirm the created path to the user and offer to start outlining or drafting the body.
+
+## Template
+
+```markdown
++++
+date = '<YYYY-MM-DD>'
+draft = true
+title = '<Title>'
++++
+
+<!-- Draft. Lives in notes/drafts/ and is NOT published.
+     When ready: move to content/posts/<slug>.md and set draft = false. -->
+
+## Introduction
+
+TODO
+```
+
+## Notes
+
+- Use TOML front matter (`+++`) to match `archetypes/default.md`, so the draft can be moved straight into `content/posts/` later.
+- Keep `draft = true` and the file under `notes/drafts/` — do NOT create it in `content/`.
+- One file per draft; never overwrite an existing draft without confirmation.

--- a/.claude/skills/publish-post/SKILL.md
+++ b/.claude/skills/publish-post/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: publish-post
+description: Publish a blog post draft from notes/drafts/ — move it into content/posts/, preview it on the local Hugo dev server so the user can review and fix issues, then finalize it (draft = false) and run a production build. Use when the user wants to publish, ship, go live with, or release a draft post — e.g. "publish my draft", "ship the post about X", "make this draft live".
+---
+
+# Publish a blog post
+
+Takes a draft from `notes/drafts/` (which Hugo never builds) into `content/posts/` (the published section — `mainSections = ['posts']` in `hugo.toml`), gives the user a live preview to fix issues, then finalizes and verifies a clean production build.
+
+**This is a two-checkpoint flow. Never set `draft = false` or build for production until the user has previewed and approved.** Publishing publicly happens only when the user later pushes to `master` (CI deploys) — this skill prepares the post and stops before pushing unless explicitly asked.
+
+## Prerequisites
+
+- Use the **extended** Hugo build (required for the SCSS). If `hugo version` doesn't show "extended", tell the user and stop.
+- Work from the repo root.
+
+## Phase 1 — Stage the draft and start a preview
+
+1. **Pick the draft.** Identify the file in `notes/drafts/` the user means. If unclear, list the `.md` files there and ask which one. Confirm the file exists.
+2. **Sanity-check the content.** Read the draft. Warn (don't block) if the body is still placeholder/`TODO` or the title looks like a default. Confirm there's a `title` in the front matter.
+3. **Choose the destination.** `content/posts/<slug>.md`, where `<slug>` is the draft's filename (keep the existing slug unless the user wants a different one). Create `content/posts/` if it doesn't exist. If a post with that name already exists, ask before overwriting.
+4. **Move the file** (move, don't copy) from `notes/drafts/<slug>.md` to `content/posts/<slug>.md`. Use `git mv` if the repo is git-tracked, otherwise `mv`.
+5. **Keep `draft = true` for now.** Leave the front matter as a draft during preview so an accidental production build won't expose it yet.
+6. **Start the dev server in the background**: run `hugo server -D` (the `-D` renders drafts). Use a background process so it keeps running while the user reviews.
+7. **Point the user to the preview.** Give them `http://localhost:1313/` and, when you can derive it, the direct post URL (typically `http://localhost:1313/posts/<slug>/`). Ask them to review and tell you about any fixes — or say it looks good.
+
+## Phase 2 — Iterate on fixes
+
+- Apply any edits the user requests directly to `content/posts/<slug>.md`. The running `hugo server` live-reloads, so they can re-check immediately.
+- Stay in this phase until the user confirms the post is ready to go live.
+
+## Phase 3 — Finalize (only after explicit user approval)
+
+1. In `content/posts/<slug>.md` front matter, set **`draft = false`** and set **`date`** to today (`date +%F`) unless the user wants to preserve the original date.
+2. Stop the background `hugo server` process.
+3. Run a production build to verify it compiles cleanly: `hugo --gc --minify`. Report success or surface any errors/warnings.
+4. Summarize what's ready: the new file path and that the post is now a non-draft. Remind the user that the post goes **publicly live only when `master` is pushed** (CI in `.github/workflows/hugo.yml` deploys to GitHub Pages).
+5. **Do not commit or push unless the user asks.** If they do, follow the repo convention: branch rather than committing directly to `master`.
+
+## Notes
+
+- Match existing front matter style: TOML (`+++`), keys `date`, `draft`, `title` (see `archetypes/default.md`).
+- Don't touch files under `themes/` (submodule). Don't leave a stray copy of the draft in `notes/drafts/` after moving.
+- If the user aborts during preview, you can move the file back to `notes/drafts/` and stop the server so nothing is left half-published.

--- a/notes/drafts/example-draft.md
+++ b/notes/drafts/example-draft.md
@@ -1,0 +1,30 @@
++++
+date = '2026-06-06'
+draft = true
+title = 'Example Draft'
++++
+
+> This is a placeholder draft living in `notes/drafts/`. Hugo never builds anything
+> under `notes/`, so this file stays private to the repo and out of the published site.
+> When a draft is ready, move it into `content/posts/` and set `draft = false`.
+
+## Introduction
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+## A Section
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa
+qui officia deserunt mollit anim id est laborum.
+
+- Sed ut perspiciatis unde omnis iste natus error.
+- Nemo enim ipsam voluptatem quia voluptas sit aspernatur.
+- Neque porro quisquam est qui dolorem ipsum quia dolor sit amet.
+
+## Conclusion
+
+At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis
+praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias.

--- a/notes/ideas.md
+++ b/notes/ideas.md
@@ -1,0 +1,5 @@
+# Blog Post Ideas
+
+A running list of post ideas. Add new ones with the `add-idea` skill, or just append below.
+
+<!-- Format: - [ ] One-line idea — optional note on the angle/why -->


### PR DESCRIPTION
## What

Adds a private `notes/` scratch space plus three Claude Code skills that support an **idea → draft → publish** workflow for the blog.

### `notes/` directory
- `notes/ideas.md` — running list of post ideas
- `notes/drafts/example-draft.md` — placeholder lorem-ipsum draft

`notes/` lives at the repo root, **outside Hugo's known content directories**, so it is tracked in git but **never built or published** to GitHub Pages. Confirmed against `.gitignore` (only `public/`, `resources/` excluded) — the folder rides along in the repo without leaking into the deployed site.

### Skills (`.claude/skills/`)
- **add-idea** — append a one-line idea to `notes/ideas.md`
- **new-draft** — scaffold a new draft at `notes/drafts/<slug>.md` with TOML front matter matching `archetypes/default.md`
- **publish-post** — move a draft into `content/posts/`, run `hugo server -D` for a live preview, iterate on fixes, then finalize (`draft = false`) and verify with `hugo --gc --minify`

## Why

Gives a lightweight, repo-tracked place to capture and develop post ideas without exposing half-baked content, and codifies the publishing steps (including a mandatory local preview) so going live is consistent and safe.

## Notes for reviewers
- No site content or config changes — nothing here affects the built site or the CI deploy.
- `publish-post` is deliberately conservative: keeps `draft = true` during preview, requires explicit approval before finalizing, and **does not commit or push** (publishing to prod still happens only via a push to `master`).
- Drafts use TOML front matter (`+++`) so they drop straight into `content/posts/` when promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)